### PR TITLE
Add numbers to %fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,22 @@ This plugin is configured through the `g:crease_foldtext` variable. It is a
 dictionary whose keys are the possible foldmethods (and `default`), and whose
 values are the foldtexts for the corresponsing foldmethods.
 
-Items starting with "%" in the foldtexts are expanded:
+Items starting with "%" in the foldtexts are expanded as described by the table
+below. `count` can be added as a number between the "%" and the item.
 
-| Item | Meaning                                                                                                   |
-|:----:|:----------------------------------------------------------------------------------------------------------|
-| %%   | A literal "%".                                                                                            |
-| %=   | Seperation point between alignment sections. Each section will be seperated by an equal number of spaces. |
-| %t   | The text in the first line of the fold, stripped of comments and fold markers.                            |
-| %l   | The number of lines in the fold.                                                                          |
-| %f   | The fold character defined in the fillchars option ("-" by default).                                      |
-| %{   | Evaluate the expression between "%{" and "}" and substitute the result.                                   |
+| Item | Meaning                                                                                                   | Count   |
+|:----:|:----------------------------------------------------------------------------------------------------------| :------ |
+| %%   | A literal "%".                                                                                            | Width   |
+| %=   | Seperation point between alignment sections. Each section will be seperated by an equal number of spaces. | Repeat  |
+| %t   | The text in the first line of the fold, stripped of comments and fold markers.                            | Width   |
+| %l   | The number of lines in the fold.                                                                          | Width   |
+| %f   | The fold character defined in the fillchars option ("-" by default).                                      | Repeat  |
+| %{   | Evaluate the expression between "%{" and "}" and substitute the result.                                   | Ignored |
+
+For the fields where `Count` gives width, this (roughly) corresponds to minimum
+field width in C style printing, where the field will be padded with spaces
+(see `:help fprint`). Where `Count` gives repeat, Adding a count will
+correspond to writing the same field `Count` times in a row.
 
 For more information, run `:help crease`
 
@@ -85,7 +91,7 @@ let g:crease_foldtext = { 'marker': '%=- %t -%=' }
 
 ```vim
 set fillchars=fold:━
-let g:crease_foldtext = { 'default': '%f%f┫ %t%{CreaseChanged()} ┣%=┫ %l lines ┣%f%f' }
+let g:crease_foldtext = { 'default': '%2f┫ %t%{CreaseChanged()} ┣%=┫%2l lines ┣%2f' }
 
 function! CreaseChanged()
     return gitgutter#fold#is_changed() ? ' *' : ''

--- a/autoload/crease.vim
+++ b/autoload/crease.vim
@@ -46,6 +46,10 @@ function! s:parse_foldtext(foldtext) abort
     return foldtext
 endfunction
 
+function! crease#debug()
+    echo s:parse_items(g:crease_foldtext['default'])
+endfunction
+
 function! s:parse_items(foldtext) abort
     let parsed_blocks = substitute(
         \ a:foldtext,
@@ -56,23 +60,28 @@ function! s:parse_items(foldtext) abort
 
     return substitute(
         \ parsed_blocks,
-        \ '\m\C%\(.\)',
-        \ '\=s:expand_item(submatch(1))',
+        \ '\m\C%\(\d*\)\(.\)',
+        \ '\=s:expand_item(submatch(2), submatch(1))',
         \ 'g'
         \ )
 endfunction
 
-function! s:expand_item(item) abort
+function! s:expand_item(item, num = 1) abort
+    if empty(a:num)
+        let num = 1
+    else
+        let num = a:num
+    endif
     if a:item ==# '%'
-        return '%'
+        return printf('%'.num.'s', '%')
     elseif a:item ==# '='
-        return ''
+        return repeat('', num)
     elseif a:item ==# 'f'
-        return s:fill_char()
+        return repeat(s:fill_char(), num)
     elseif a:item ==# 't'
-        return s:stripped_fold_text()
+        return printf('%'.num.'s', s:stripped_fold_text())
     elseif a:item ==# 'l'
-        return v:foldend - v:foldstart + 1
+        return printf('%'.num.'d', v:foldend - v:foldstart + 1)
     endif
 
     return '%' . a:item

--- a/doc/crease.txt
+++ b/doc/crease.txt
@@ -49,16 +49,20 @@ plugin manager.
         |foldtext| consists of |printf| and |statusline| style '%' items interspersed
         with normal text.
 
-        item  meaning ~
-        %     A literal "%".
-        =     Seperation point between alignment sections. Each section will be
-              seperated by an equal number of spaces.
-        t     The text in the first line of the fold, stripped of comments and
-              fold markers.
-        l     The number of lines in the fold.
-        f     The fold character defined in |fillchars| ("-" by default).
-        {     Evaluate the expression between "%{" and "}" and substitute
+        item  meaning                                                       count ~
+        %     A literal "%".                                                width
+        =     Seperation point between alignment sections. Each section     repeat
+              will be seperated by an equal number of spaces.
+        t     The text in the first line of the fold, stripped of comments  width
+              and fold markers.
+        l     The number of lines in the fold.                              width
+        f     The fold character defined in |fillchars| ("-" by default).   repeat
+        {     Evaluate the expression between "%{" and "}" and substitute   ignored
               the result.
+
+        A count can be given between the "%" and the symbol, like `%4l`, which
+        either gives the minimum width (to be padded with spaces), or a number
+        of times to repeat the command, as indicated in the table.
 
         Note that the %{} items are expanded before the rest of the items,
         meaning another item could be returned from the expression within.
@@ -80,7 +84,7 @@ Using |gitgutter#fold#is_changed()|:
 >
     set fillchars=\-
     let g:crease_foldtext = {
-            \ 'default': '%f%f[ %t%{CreaseModified()} ]%=[ %l lines ]%f%f'
+            \ 'default': '%2f[ %t%{CreaseModified()} ]%=[%4l lines ]%2f'
             \ }
     function! CreaseModified()
         return gitgutter#fold#is_changed() ? ' *' : ''


### PR DESCRIPTION
This solves two problems I've seen with crease:
1. Filling with large(ish) numbers of fillchars meant writing `%f` many times in a row
2. It was difficult to control width of fields

With this change, you can make things like below:
![crease](https://user-images.githubusercontent.com/6677110/165528539-5c8035b4-a8b6-41b2-b258-b637a43a01fc.png)

My foldtext is below, the important parts are `%25t`, `%4l`, `%8f`. Note how the first two would have been harder to align, and the last one used to be `%f%f%f%f%f%f%f%f`.
```vim
let g:crease_foldtext = { 'default': '┠──%{gitgutter#fold#is_changed() ? ''╯ ╭'' : ''───''}─%{functions#FoldIsCommented() ? ''╳'' : ''─''}─┨%25t ┠%=╢%4l lines ╟%8f┨ ' }
```

Bonus: `a%=b%3=c` is a compact way to make weighted alignment, with triple the distance between b and c as between a and b.